### PR TITLE
A one line pipe using sed and dc to solve the first Advent of Code 20…

### DIFF
--- a/cmd2-one-line-pipe
+++ b/cmd2-one-line-pipe
@@ -1,0 +1,3 @@
+#!/bin/bash
+cat cmd2realtest | sed -e s/one/o1e/g -e s/two/t2o/g -e s/three/thr3e/g -e s/four/fo4ur/g -e s/five/f5e/g -e s/six/s6x/g -e s/seven/s7n/g -e s/eight/e8t/g -e s/nine/n9e/g  | sed -r "s/[[:alpha:]]+//g" | sed  "s/^\([[:digit:]]\{1,1\}\)$/\1\1/"  |  sed "s/^\([[:digit:]]\)[[:digit:]]\{1,255\}\([[:digit:]]\)$/\1\2/" | sed "2,$ a\+" | sed "$,$ a\p" | dc
+


### PR DESCRIPTION
…23 problem

I made the command a bash script for the MUG repo.

The file cmd2realtest was my assigned input.

This was meant to be fun and a stretch to finally get around to using some traditional Unix programs I read about in the summer of 1985. I did it this way because I'd learn something new. I'm sure there are many who could construct a solution like this far better than me.

The sed pipe appeals to me because of its functional approach (vs. procedural), but it would be awful as a work product because so few people know regular expressions well enough to look at one and know what it is doing with clarity and confidence. Those are two benefits I would hope to get out of a functional programming approach normally. Work products should be maintainable by a large number of people.

I started with a cat command because I wanted the file input to be a separate stage. I could have had fewer stages by combining edits within a single sed invocation -- but this appealed to me as more fun.

The dc command uses reverse Polish notation and therefore needs two numbers to be stacked before asking for an addition.